### PR TITLE
Undefined state after Reset or Inject

### DIFF
--- a/include/singleton.hpp
+++ b/include/singleton.hpp
@@ -76,9 +76,7 @@ private:
         Instance(const Instance&) = delete;
         ~Instance()
         {
-            // Destroys the locally-initialized instance. Injected ones are ignored (no ownership).
-            if (m_pExtern == LOCAL_INSTANCE_ID)
-                GetBuffer().~T();
+            DestroyLocalInstance();
         }
         Instance& operator =(const Instance&) = delete;
         /// Returns the current instance.
@@ -91,7 +89,7 @@ private:
         template <typename ...Args>
         void Emplace(Args&&... args)
         {
-            this->~Instance();
+            DestroyLocalInstance();
             try
             {
                 new (&GetBuffer()) T(std::forward<Args>(args)...);
@@ -108,7 +106,7 @@ private:
           */
         void SetExtern(T* ptr)
         {
-            this->~Instance();
+            DestroyLocalInstance();
             m_pExtern = ptr;
         }
     private:
@@ -123,6 +121,13 @@ private:
             // Static, uninitialized buffer for the singleton's object
             static union U { T asT; U(){} ~U(){} } buffer;
             return buffer.asT;
+        }
+		/// Destroys the local instance, while ignoring injected ones (no ownership).
+        /** @remark This leaves the object in an inconsistent state. m_pExtern must be changed. */
+        void DestroyLocalInstance()
+        {
+            if (m_pExtern == LOCAL_INSTANCE_ID)
+                GetBuffer().~T();
         }
     } g_instance;
 


### PR DESCRIPTION
Fixed possible undefined state after calling Reset or Inject on the singleton.

Closes #6 